### PR TITLE
Fixing missing underscore in EXAMPLE_SOURCE_FILES

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ else
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)
-EXAMPLE_SOURCE FILES := $(shell find $(EXAMPLES_DIR) -name \*.pony)
+EXAMPLE_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name \*.pony)
 
 test: unit-tests build-examples
 


### PR DESCRIPTION
Fixing missing underscore preventing initialization of EXAMPLE_SOURCE_FILES variable